### PR TITLE
HOTFIX: UseEffect Dependency Remove

### DIFF
--- a/src/components/boards/suggestion/post/Post.tsx
+++ b/src/components/boards/suggestion/post/Post.tsx
@@ -257,7 +257,7 @@ function Post() {
       .catch((err) => {
         // 에러 처리
       });
-  }, [post]);
+  }, []);
 
   const onCommentHandler = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();


### PR DESCRIPTION
## 배경 : react hook에서 dependency를 post가 설정되어 있었기에 요청이 무한히 들어옴

```
useEffect(() => {
    axios({
      url: `/api/suggestion/${postId}`,
      method: 'get',
      headers: {
        'X-AUTH-TOKEN': cookies['X-AUTH-TOKEN'],
      },
    })
      .then((res) => {
        setPost(res.data.data);
      })
      .catch((err) => {
        // 에러 처리
      });
  }, [post -> 삭제]); 
```

이유 : post요청시 현재 조회수가 계속 증가하므로, 매 요청의 res값이 다름(조회수값이 변동됨)

수정 : Dependency 제거